### PR TITLE
Updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ production (current)
 ##Installation
 #####Install from CLI
   ```
-  $ cf add-plugin-repo CF-Community http://plugins.cloudfoundry.org/
-  $ cf install-plugin targets -r CF-Community
+  $ cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org/
+  $ cf install-plugin Targets -r CF-Community
   ```
   
   


### PR DESCRIPTION
added https rather than http for community repo
fixed name of the plugin to have a capital "Targets" since lower case "targets" did not work.